### PR TITLE
Clear cache according to a maximum age since modification

### DIFF
--- a/Q42.WinRT/Data/DataCache.cs
+++ b/Q42.WinRT/Data/DataCache.cs
@@ -174,6 +174,38 @@ namespace Q42.WinRT.Data
     }
 
     /// <summary>
+    /// Clears the cache by removing all the files which have not been modified
+    /// for a given time
+    /// </summary>
+    /// <param name="maxAge">
+    /// Files that have not been modified for more than this time span will be deleted
+    /// </param>
+    public static async Task Clear(TimeSpan maxAge)
+    {
+        var storage = new StorageHelper<object>(StorageType.Local, CacheFolder);
+        var folder = await storage.GetFolderAsync();
+
+        await Clear(folder, maxAge);
+
+    }
+      
+    public static async Task Clear(this StorageFolder folder, TimeSpan maxAge)
+    {
+        var files = await folder.GetFilesAsync();
+
+        foreach (var file in files)
+        {
+            var props = await file.GetBasicPropertiesAsync();
+            var age = DateTimeOffset.UtcNow - props.DateModified;
+            if (age >= maxAge)
+            {
+                await file.DeleteAsync(StorageDeleteOption.PermanentDelete);
+            }
+        }
+    }
+
+
+    /// <summary>
     /// Clears the cache untill the total size is below the maxSize
     /// </summary>
     /// <param name="maxSize">MaxSize in bytes</param>

--- a/Q42.WinRT/Data/WebDataCache.cs
+++ b/Q42.WinRT/Data/WebDataCache.cs
@@ -162,5 +162,12 @@ namespace Q42.WinRT.Data
           await folder.Clear(maxSize);
 
         }
+
+        public static async Task Clear(TimeSpan maxAge)
+        {
+            var folder = await GetFolderAsync().ConfigureAwait(false);
+
+            await folder.Clear(maxAge);
+        }
     }
 }


### PR DESCRIPTION
This is my idea on how to clear the cache using a maximum age as threshold similar to the clear by maxsize API. While the image expire time is available this could be used